### PR TITLE
finish combos on linux with RET

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The `UC_MODE_LINUX` input system has one configurable property `linux-key`,
 which defaults to `LC(LS(U))`. The system will:
   1. tap and release `linux-key` (`LC(LS(U))` by default)
   2. input the code point sequence
-  3. tap and release `SPACE`
+  3. tap and release `RETURN`
 
 To overwrite `linux-key`, add the following outside of the root node of your
 keymap:

--- a/src/behaviors/behavior_unicode.c
+++ b/src/behaviors/behavior_unicode.c
@@ -151,7 +151,7 @@ void unicode_input_stop(const struct zmk_behavior_binding_event *event) {
         queue_key_release(event, &binding, cfg->macos_key);
         break;
     case UC_MODE_LINUX:
-        queue_key_tap(event, &binding, SPACE);
+        queue_key_tap(event, &binding, RET);
         break;
     case UC_MODE_LINUX_ALT:
         queue_key_tap(event, &binding, SPACE);


### PR DESCRIPTION
changed the finish key to `Return` as mentioned in [my issue](https://github.com/urob/zmk-unicode/issues/13)